### PR TITLE
Update KTM RC generations: Added Wikipedia reference and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# KTM RC
+
+This repository contains signal set configurations for the KTM RC, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the KTM RC.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/KTM_390_series"
+
 generations:
   - name: "First Generation"
     start_year: 2014


### PR DESCRIPTION
- Added references section with KTM 390 series Wikipedia URL
- Updated README.md with standard vehicle template
- Verified generation data against Wikipedia article confirming:
  - First Generation (2014-2021): Original RC series with updates in 2017
  - Second Generation (2022-present): New generation with cornering ABS, TC, and quickshifter
